### PR TITLE
Remove releasing of TStream inside class

### DIFF
--- a/qtemplate.pp
+++ b/qtemplate.pp
@@ -132,7 +132,6 @@ begin
         end;
     finally
      FreeAndNil(S);
-     FreeAndNil(FStream);
     end;
 end;
 


### PR DESCRIPTION
An external TStream object  must not be freed inside TQTemplate!
Lead to errors. For example, an attempt to reuse a AStream that was unexpectedly released inside QTemplate class